### PR TITLE
fix: troubleshooting waveforms being activated immediately when a page is first rendered (#14)

### DIFF
--- a/client/src/component/presentation/Practice.js
+++ b/client/src/component/presentation/Practice.js
@@ -65,7 +65,7 @@ const LoadingText = styled.div`
   background-color: black;
   color: white;
   font-weight: bold;
-  z-index: 1;
+  z-index: 100;
   padding: 20px 10px 20px 10px;
 `;
 


### PR DESCRIPTION
## 업데이트 유형
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## 업데이트 개요
* Fix #14


## 업데이트 요약
연습 화면이 렌더링 되자마자 활성화된 파형이 보여지는 것을 막기 위해 파형 엘리먼트 커버 적용 
